### PR TITLE
Removed configureAttributeReporting() for CLUSTER.ON_OFF

### DIFF
--- a/lib/switch.js
+++ b/lib/switch.js
@@ -12,16 +12,6 @@ class Switch extends ZigBeeDevice {
 		await super.onNodeInit({ zclNode });
 		if (this.hasCapability('onoff')) {
 			this.registerCapability('onoff', CLUSTER.ON_OFF);
-
-			await this.configureAttributeReporting([
-				{
-					endpointId: 1,
-					cluster: CLUSTER.ON_OFF,
-					attributeName: 'onOff',
-					minInterval: 0,
-					maxInterval: 300,
-				},
-			]);
 		}
 
 		// add capability meter_power if not already present like in sdkv2 driver

--- a/lib/switch2.js
+++ b/lib/switch2.js
@@ -23,16 +23,6 @@ class SecondSwitch extends ZigBeeDevice {
         endpoint: 2,
       });
 
-      await this.configureAttributeReporting([
-          {
-            endpointId: 2,
-            cluster: CLUSTER.ON_OFF,
-            attributeName: 'onOff',
-            minInterval: 0,
-            maxInterval: 300,
-          },
-        ]);
-
     }
 
   }


### PR DESCRIPTION
registerCapability() configures attribute reporting by default. 
Probably not needed in dimmer.js either for the CLUSTER.ON_OFF and CLUSTER.LEVEL_CONTROL reports.